### PR TITLE
Add writer metadata support

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -90,6 +90,11 @@ class JSONAgent(Agent.Movies):
             director = metadata.directors.new()
             director.name = d.get('name')
 
+        metadata.writers.clear()
+        for w in info.writers():
+            writer = metadata.writers.new()
+            writer.name = w.get('name')
+
         metadata.genres.clear()
         for g in info.genres():
             metadata.genres.add(g)

--- a/Contents/Code/jinf.py
+++ b/Contents/Code/jinf.py
@@ -81,6 +81,23 @@ class Jinf:
             if is_valid_director(director)
         ]
 
+    def writers(self):
+        def is_valid_writer(writer):
+            return (
+                isinstance(writer, dict) and
+                isinstance(writer.get('name'), (str, unicode)) and
+                str(writer.get('name')).strip()
+            )
+
+        def extract_writer_info(writer):
+            return {'name': str(writer.get('name')).strip()}
+
+        return [
+            extract_writer_info(writer)
+            for writer in self.get_array('writers')
+            if is_valid_writer(writer)
+        ]
+
     def actors(self):
         def is_valid_actor(actor):
             return (

--- a/README.md
+++ b/README.md
@@ -57,8 +57,13 @@ The structure of the `Info.json` file follows as closely as possible that of the
             "name": "Katsuhiro Ōtomo"
         }
     ],
+    "writers": [
+        {
+            "name": "Izô Hashimoto"
+        }
+    ],
     "actors": [
-    	{
+        {
             "name": "Mitsuo Iwata",
             "role": "Shôtarô Kaneda"
         },

--- a/movie-schema.json
+++ b/movie-schema.json
@@ -62,6 +62,18 @@
         "required": ["name"]
       }
     },
+    "writers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      }
+    },
     "actors": {
       "type": "array",
       "items": {

--- a/tests/test_jinf.py
+++ b/tests/test_jinf.py
@@ -5,6 +5,7 @@ import tempfile
 import types
 import importlib
 import builtins
+import json
 
 class DummyStorage:
     def load(self, path):
@@ -43,6 +44,27 @@ class LoadFileTest(unittest.TestCase):
             with self.assertRaises(Exception) as ctx:
                 self.jinf.Jinf.load_file(tmp_path)
             self.assertIn('Invalid JSON', str(ctx.exception))
+        finally:
+            os.unlink(tmp_path)
+
+    def test_writers(self):
+        data = {
+            "title": "Test",
+            "year": 2020,
+            "writers": [
+                {"name": "Writer One"},
+                {"name": "Writer Two"}
+            ]
+        }
+        with tempfile.NamedTemporaryFile('w', delete=False) as tmp:
+            tmp.write(json.dumps(data))
+            tmp_path = tmp.name
+        try:
+            info = self.jinf.Jinf.load_file(tmp_path)
+            self.assertEqual(info.writers(), [
+                {"name": "Writer One"},
+                {"name": "Writer Two"}
+            ])
         finally:
             os.unlink(tmp_path)
 


### PR DESCRIPTION
## Summary
- support "writers" metadata in Jinf and agent update logic
- extend movie schema to describe writers
- document writers in README example
- test writer parsing

## Testing
- `python tests/test_jinf.py`