### PR TITLE
Add support for producers

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -90,6 +90,11 @@ class JSONAgent(Agent.Movies):
             director = metadata.directors.new()
             director.name = d.get('name')
 
+        metadata.producers.clear()
+        for p in info.producers():
+            producer = metadata.producers.new()
+            producer.name = p.get('name')
+
         metadata.genres.clear()
         for g in info.genres():
             metadata.genres.add(g)

--- a/Contents/Code/jinf.py
+++ b/Contents/Code/jinf.py
@@ -81,6 +81,23 @@ class Jinf:
             if is_valid_director(director)
         ]
 
+    def producers(self):
+        def is_valid_producer(producer):
+            return (
+                isinstance(producer, dict) and
+                isinstance(producer.get('name'), (str, unicode)) and
+                str(producer.get('name')).strip()
+            )
+
+        def extract_producer_info(producer):
+            return {'name': str(producer.get('name')).strip()}
+
+        return [
+            extract_producer_info(producer)
+            for producer in self.get_array('producers')
+            if is_valid_producer(producer)
+        ]
+
     def actors(self):
         def is_valid_actor(actor):
             return (

--- a/README.md
+++ b/README.md
@@ -57,8 +57,13 @@ The structure of the `Info.json` file follows as closely as possible that of the
             "name": "Katsuhiro Ōtomo"
         }
     ],
+    "producers": [
+        {
+            "name": "Shigeru Watanabe"
+        }
+    ],
     "actors": [
-    	{
+        {
             "name": "Mitsuo Iwata",
             "role": "Shôtarô Kaneda"
         },

--- a/movie-schema.json
+++ b/movie-schema.json
@@ -62,6 +62,18 @@
         "required": ["name"]
       }
     },
+    "producers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      }
+    },
     "actors": {
       "type": "array",
       "items": {

--- a/tests/test_jinf.py
+++ b/tests/test_jinf.py
@@ -5,6 +5,7 @@ import tempfile
 import types
 import importlib
 import builtins
+import json
 
 class DummyStorage:
     def load(self, path):
@@ -43,6 +44,27 @@ class LoadFileTest(unittest.TestCase):
             with self.assertRaises(Exception) as ctx:
                 self.jinf.Jinf.load_file(tmp_path)
             self.assertIn('Invalid JSON', str(ctx.exception))
+        finally:
+            os.unlink(tmp_path)
+
+    def test_producers(self):
+        info = {
+            "title": "Test",
+            "year": 2000,
+            "producers": [
+                {"name": "Prod A"},
+                {"name": "Prod B"}
+            ]
+        }
+        with tempfile.NamedTemporaryFile('w', delete=False) as tmp:
+            tmp.write(json.dumps(info))
+            tmp_path = tmp.name
+        try:
+            j = self.jinf.Jinf.load_file(tmp_path)
+            self.assertEqual(j.producers(), [
+                {"name": "Prod A"},
+                {"name": "Prod B"}
+            ])
         finally:
             os.unlink(tmp_path)
 


### PR DESCRIPTION
## Summary
- support `producers` in Info.json parsing
- expose producer metadata to Plex
- document `producers` field in README and schema
- test producer parsing in `jinf`

## Testing
- `python -m unittest tests.test_jinf -v`
