### PR TITLE
Add producers support

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -95,6 +95,11 @@ class JSONAgent(Agent.Movies):
             writer = metadata.writers.new()
             writer.name = w.get('name')
 
+        metadata.producers.clear()
+        for p in info.producers():
+            producer = metadata.producers.new()
+            producer.name = p.get('name')
+
         metadata.genres.clear()
         for g in info.genres():
             metadata.genres.add(g)

--- a/Contents/Code/jinf.py
+++ b/Contents/Code/jinf.py
@@ -98,6 +98,23 @@ class Jinf:
             if is_valid_writer(writer)
         ]
 
+    def producers(self):
+        def is_valid_producer(producer):
+            return (
+                isinstance(producer, dict) and
+                isinstance(producer.get('name'), (str, unicode)) and
+                str(producer.get('name')).strip()
+            )
+
+        def extract_producer_info(producer):
+            return {'name': str(producer.get('name')).strip()}
+
+        return [
+            extract_producer_info(producer)
+            for producer in self.get_array('producers')
+            if is_valid_producer(producer)
+        ]
+
     def actors(self):
         def is_valid_actor(actor):
             return (

--- a/movie-schema.json
+++ b/movie-schema.json
@@ -74,6 +74,18 @@
         "required": ["name"]
       }
     },
+    "producers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      }
+    },
     "actors": {
       "type": "array",
       "items": {

--- a/tests/test_jinf.py
+++ b/tests/test_jinf.py
@@ -68,5 +68,26 @@ class LoadFileTest(unittest.TestCase):
         finally:
             os.unlink(tmp_path)
 
+    def test_producers(self):
+        data = {
+            "title": "Test",
+            "year": 2020,
+            "producers": [
+                {"name": "Producer One"},
+                {"name": "Producer Two"}
+            ]
+        }
+        with tempfile.NamedTemporaryFile('w', delete=False) as tmp:
+            tmp.write(json.dumps(data))
+            tmp_path = tmp.name
+        try:
+            info = self.jinf.Jinf.load_file(tmp_path)
+            self.assertEqual(info.producers(), [
+                {"name": "Producer One"},
+                {"name": "Producer Two"}
+            ])
+        finally:
+            os.unlink(tmp_path)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow Info.json to include producers arrays
- handle producers in Plex metadata
- test the new producers functionality

## Testing
- `python -m unittest tests.test_jinf -v`