### PR TITLE
Use fixture file for comprehensive tests

### DIFF
--- a/tests/fixtures/all_fields.json
+++ b/tests/fixtures/all_fields.json
@@ -1,0 +1,33 @@
+{
+    "title": "Test Movie",
+    "original_title": "Original Title",
+    "tagline": "Just a test",
+    "summary": "This is a test.",
+    "year": 2021,
+    "release_date": "2021-05-04",
+    "rating": 8.2,
+    "content_rating": "PG",
+    "studio": "Test Studio",
+    "duration": 123,
+    "directors": [
+        {"name": "Director One"},
+        {"name": "Director Two"}
+    ],
+    "writers": [
+        {"name": "Writer One"}
+    ],
+    "producers": [
+        {"name": "Producer One"}
+    ],
+    "actors": [
+        {
+            "name": "Actor One",
+            "role": "Hero",
+            "thumb": "http://example.com/one.jpg"
+        },
+        {"name": "Actor Two"}
+    ],
+    "genres": ["Drama", " Action "],
+    "collections": ["Collection1"],
+    "countries": ["USA", "Japan"]
+}

--- a/tests/test_jinf.py
+++ b/tests/test_jinf.py
@@ -6,6 +6,7 @@ import types
 import importlib
 import builtins
 import json
+from datetime import datetime, date
 
 class DummyStorage:
     def load(self, path):
@@ -15,6 +16,11 @@ class DummyStorage:
 class DummyCore:
     def __init__(self):
         self.storage = DummyStorage()
+
+class DummyDatetime:
+    @staticmethod
+    def ParseDate(value):
+        return datetime.strptime(value, "%Y-%m-%d")
 
 def load_jinf():
     builtins.unicode = str
@@ -29,12 +35,15 @@ class LoadFileTest(unittest.TestCase):
     def setUp(self):
         self.jinf = load_jinf()
         self.jinf.Core = DummyCore()
+        self.jinf.Datetime = DummyDatetime
 
     def tearDown(self):
         sys.modules.pop('urlparse', None)
         code_path = os.path.join(os.path.dirname(__file__), '..', 'Contents', 'Code')
         if code_path in sys.path:
             sys.path.remove(code_path)
+        if hasattr(self.jinf, 'Datetime'):
+            delattr(self.jinf, 'Datetime')
 
     def test_invalid_json(self):
         with tempfile.NamedTemporaryFile('w', delete=False) as tmp:
@@ -86,6 +95,73 @@ class LoadFileTest(unittest.TestCase):
                 {"name": "Producer One"},
                 {"name": "Producer Two"}
             ])
+        finally:
+            os.unlink(tmp_path)
+
+    def test_all_fields(self):
+        fixture_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "all_fields.json"
+        )
+        info = self.jinf.Jinf.load_file(fixture_path)
+        self.assertEqual(info.title(), "Test Movie")
+        self.assertEqual(info.original_title(), "Original Title")
+        self.assertEqual(info.tagline(), "Just a test")
+        self.assertEqual(info.summary(), "This is a test.")
+        self.assertEqual(info.year(), 2021)
+        self.assertEqual(info.release_date(), date(2021, 5, 4))
+        self.assertEqual(info.rating(), 8.2)
+        self.assertEqual(info.content_rating(), "PG")
+        self.assertEqual(info.studio(), "Test Studio")
+        self.assertEqual(info.duration(), 123)
+        self.assertEqual(info.directors(), [
+            {"name": "Director One"},
+            {"name": "Director Two"}
+        ])
+        self.assertEqual(info.writers(), [
+            {"name": "Writer One"}
+        ])
+        self.assertEqual(info.producers(), [
+            {"name": "Producer One"}
+        ])
+        self.assertEqual(info.actors(), [
+            {
+                "name": "Actor One",
+                "role": "Hero",
+                "thumb": "http://example.com/one.jpg"
+            },
+            {"name": "Actor Two"}
+        ])
+        self.assertEqual(list(info.genres()), ["Drama", "Action"])
+        self.assertEqual(list(info.collections()), ["Collection1"])
+        self.assertEqual(list(info.countries()), ["USA", "Japan"])
+
+    def test_summary_from_description(self):
+        data = {
+            "title": "Test",
+            "year": 2020,
+            "description": "Desc"
+        }
+        with tempfile.NamedTemporaryFile('w', delete=False) as tmp:
+            tmp.write(json.dumps(data))
+            tmp_path = tmp.name
+        try:
+            info = self.jinf.Jinf.load_file(tmp_path)
+            self.assertEqual(info.summary(), "Desc")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_year_from_release_date(self):
+        data = {
+            "title": "Test",
+            "release_date": "2022-01-02"
+        }
+        with tempfile.NamedTemporaryFile('w', delete=False) as tmp:
+            tmp.write(json.dumps(data))
+            tmp_path = tmp.name
+        try:
+            info = self.jinf.Jinf.load_file(tmp_path)
+            self.assertEqual(info.year(), 2022)
+            self.assertEqual(info.release_date(), date(2022, 1, 2))
         finally:
             os.unlink(tmp_path)
 


### PR DESCRIPTION
## Summary
- add an `all_fields.json` fixture for tests
- update the `test_all_fields` case to load from the fixture

## Testing
- `python -m unittest tests.test_jinf -v`